### PR TITLE
"New build" pre-populates the project dropdown.

### DIFF
--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -19,7 +19,7 @@ class BuildsController < ApplicationController
 
   # GET /builds/new
   def new
-    @build = Build.new(:sha => "master")
+    @build = Build.new(:sha => "master", :project_id => params[:project_id])
   end
 
   # GET /builds/1/edit

--- a/app/views/builds/index.html.erb
+++ b/app/views/builds/index.html.erb
@@ -1,6 +1,6 @@
 <div class="page-header">
   <div class="page-actions">
-    <%= link_to 'New Build', new_build_path, :class => "button" %>
+    <%= link_to 'New Build', @project ? new_project_build_path(@project) : new_build_path, :class => "button" %>
   </div>
   <div class="page-title">
     <% if @project %>


### PR DESCRIPTION
A small tweak to get started. If you click "New build" from a specific project's build page, the project dropdown is
prepopulated with that project.
