### PR TITLE
Quiet some ActiveRecord deprecations.

### DIFF
--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -8,7 +8,7 @@ class BuildsController < ApplicationController
       @project = Project.find(params[:project_id])
       @builds = @project.builds
     else
-      @builds = Build.all(:order => "created_at DESC")
+      @builds = Build.order("created_at DESC")
     end
   end
 

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -45,11 +45,11 @@ class Build < ActiveRecord::Base
         "#{status_word} in #{duration}"
       end
     when :pending
-      "Build started #{distance_of_time_in_words_to_now(started_at, true)} ago"
+      "Build started #{distance_of_time_in_words_to_now(started_at, :include_seconds => true)} ago"
     when :mia
       "Missing, presumed dead"
     when :queued
-      "#{status_word} #{distance_of_time_in_words_to_now(created_at, true)} ago"
+      "#{status_word} #{distance_of_time_in_words_to_now(created_at, :include_seconds => true)} ago"
     end
 
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,7 @@
         <li class="project all-builds">
           <%= link_to "All Builds", root_path, :class => "#{'selected' if current_page?(root_path)}" %>
         </li>
-        <% Project.find(:all).each do |project| %>
+        <% Project.all.each do |project| %>
           <li class="project">
             <%= link_to project.repo, project_builds_path(project), :class => "#{'selected' if current_page?(project_builds_path(project))}" %>
           </li>


### PR DESCRIPTION
I noticed some ActiveRecord deprecations showing up in the logs while I was clicking around:

```
11:31:25 web.1    | DEPRECATION WARNING: Calling #find(:all) is deprecated. Please call #all directly instead. (called from _app_views_layouts_application_html_erb___2567121074465464710_32706380 at /home/smash/src/dciy/app/views/layouts/application.html.erb:24)
11:31:25 web.1    | DEPRECATION WARNING: Relation#all is deprecated. If you want to eager-load a relation, you can call #load (e.g. `Post.where(published: true).load`). If you want
 to get an array of records from a relation, you can call #to_a (e.g. `Post.where(published: true).to_a`). (called from _app_views_layouts_application_html_erb___2567121074465464710_32706380 at /home/smash/src/dciy/app/views/layouts/application.html.erb:24)
```

This tweaks the arel code to use undeprecated alternatives.
