### PR TITLE
Prevent duplicate output appending.

### DIFF
--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -72,10 +72,7 @@ EOF
   end
 
   def add_output(chunk)
-    output = @build.output
-    output << chunk
-    @build.output = output
-    @build.save
+    @build.update(:output => @build.output + chunk)
   end
 
   def add_dciy_build_output(message)
@@ -86,8 +83,7 @@ EOF
     @logger.info "Build #{@build.sha} exited with #{@result.success} got:\n #{@result.output}"
     @build.update(
       :completed_at => Time.now,
-      :successful   => @result.success,
-      :output       => @build.output + @result.output
+      :successful   => @result.success
     )
   end
 


### PR DESCRIPTION
Output was being appended by both `#add_output` calls during the build and out of the command Result in `#complete` for successful builds, hence the duplicate output.

Also, I think `#add_output` had a bug as well - modifying the attribute String in place (with `#<<`) wasn't triggering ActiveRecord's dirty flag for the `:output` attribute, so the `#save` call wasn't actually persisting the change!

```
2.0.0p247 :001 > b = Build.new(:sha => 'master', :project_id => 1)
 => #<Build id: nil, project_id: 1, started_at: nil, completed_at: nil, successful: nil, output: nil, created_at: nil, updated_at: nil, sha: "master">
2.0.0p247 :002 > b.save
   (0.2ms)  begin transaction
  SQL (4.8ms)  INSERT INTO "builds" ("created_at", "project_id", "sha", "updated_at") VALUES (?, ?, ?, ?)  [["created_at", Sat, 14 Sep 2013 19:01:09 UTC +00:00], ["project_id", 1],
 ["sha", "master"], ["updated_at", Sat, 14 Sep 2013 19:01:09 UTC +00:00]]
   (169.2ms)  commit transaction
 => true
2.0.0p247 :003 > b.output = "foo"
 => "foo"
2.0.0p247 :004 > b.save
   (0.2ms)  begin transaction
  SQL (0.6ms)  UPDATE "builds" SET "output" = ?, "updated_at" = ? WHERE "builds"."id" = 33  [["output", "foo"], ["updated_at", Sat, 14 Sep 2013 19:01:22 UTC +00:00]]
   (145.7ms)  commit transaction
 => true
2.0.0p247 :005 > b.output << " and bar"
 => "foo and bar"
2.0.0p247 :006 > b.save
   (0.1ms)  begin transaction
   (0.1ms)  commit transaction
 => true
2.0.0p247 :007 >
```
