### PR TITLE
Simple GitHub status API integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Set the variables below to enable GitHub Commit Status API integration.
+GITHUB_API_USER=REPLACEME
+GITHUB_API_TOKEN=REPLACEME

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'dotenv-rails'
 gem 'foreman'
 gem 'sidekiq'
 gem 'sinatra', '>= 1.3.0', :require => nil
+gem 'rest-client'
 
 group :development do
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,8 @@ GEM
     redis (3.0.4)
     redis-namespace (1.3.1)
       redis (~> 3.0.0)
+    rest-client (1.6.7)
+      mime-types (>= 1.16)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
@@ -150,6 +152,7 @@ DEPENDENCIES
   jbuilder (~> 1.2)
   jquery-rails
   rails (= 4.0.0)
+  rest-client
   rspec
   rspec-rails
   sass-rails (~> 4.0.0)

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -90,7 +90,7 @@ class Build < ActiveRecord::Base
   end
 
   def mark_status_on_github_as(state)
-    CommitStatus.mark(self.project.repo, self.sha, state)
+    CommitStatus.mark(self.id, state)
   end
 
 end

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -89,4 +89,8 @@ class Build < ActiveRecord::Base
     (Time.now - time) > 1.hour
   end
 
+  def mark_status_on_github_as(state)
+    CommitStatus.mark(self.project.repo, self.sha, state)
+  end
+
 end

--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -8,26 +8,28 @@ class CommitStatus
       ENV["GITHUB_API_USER"].present? && ENV["GITHUB_API_TOKEN"].present?
     end
 
-    def mark(repo_name, sha, state)
+    def mark(build_id, state)
+
+      build = Build.find(build_id)
 
       case state
       when :pending
         message = "Build pending."
       when :success
-        message = status_phrase
+        message = build.status_phrase
       when :error
-        message = status_phrase
+        message = build.status_phrase
       when :failure
-        message = status_phrase
+        message = build.status_phrase
       end
 
       commit_status = {
         "state" => state.to_s,
         "description" => message,
-        "target_url" => "http://localhost:6161/builds/#{self.id}"
+        "target_url" => "http://localhost:6161/builds/#{build.id}"
       }
 
-      endpoint = "https://api.github.com/repos/#{repo_name}/statuses/#{sha}"
+      endpoint = "https://api.github.com/repos/#{build.project.repo}/statuses/#{build.sha}"
       repo = RestClient::Resource.new endpoint, ENV["GITHUB_API_USER"], ENV["GITHUB_API_TOKEN"]
 
       response = repo.post commit_status.to_json, :content_type => :json, :accept => :json

--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -1,0 +1,38 @@
+require 'rest_client'
+
+class CommitStatus
+
+  class << self
+
+    def enabled?
+      ENV["GITHUB_API_USER"].present? && ENV["GITHUB_API_TOKEN"].present?
+    end
+
+    def mark(repo_name, sha, state)
+
+      case state
+      when :pending
+        message = "Build pending."
+      when :success
+        message = status_phrase
+      when :error
+        message = status_phrase
+      when :failure
+        message = status_phrase
+      end
+
+      commit_status = {
+        "state" => state.to_s,
+        "description" => message,
+        "target_url" => "http://localhost:6161/builds/#{self.id}"
+      }
+
+      endpoint = "https://api.github.com/repos/#{repo_name}/statuses/#{sha}"
+      repo = RestClient::Resource.new endpoint, ENV["GITHUB_API_USER"], ENV["GITHUB_API_TOKEN"]
+
+      response = repo.post commit_status.to_json, :content_type => :json, :accept => :json
+    end
+
+  end
+
+end

--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -12,14 +12,9 @@ class CommitStatus
 
       build = Build.find(build_id)
 
-      case state
-      when :pending
+      if state == :pending
         message = "Build pending."
-      when :success
-        message = build.status_phrase
-      when :error
-        message = build.status_phrase
-      when :failure
+      elsif [:success, :error, :failure].include? state
         message = build.status_phrase
       end
 
@@ -30,9 +25,9 @@ class CommitStatus
       }
 
       endpoint = "https://api.github.com/repos/#{build.project.repo}/statuses/#{build.sha}"
-      repo = RestClient::Resource.new endpoint, ENV["GITHUB_API_USER"], ENV["GITHUB_API_TOKEN"]
+      repo_api = RestClient::Resource.new endpoint, ENV["GITHUB_API_USER"], ENV["GITHUB_API_TOKEN"]
 
-      response = repo.post commit_status.to_json, :content_type => :json, :accept => :json
+      response = repo_api.post commit_status.to_json, :content_type => :json, :accept => :json
     end
 
   end

--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -75,6 +75,8 @@ EOF
     add_dciy_build_output "Setting up submodules, if you're into that kind of thing..."
     in_terminal.run "git submodule init", @directory
     in_terminal.run "git submodule update", @directory
+
+    @build.mark_status_on_github_as(:pending) if CommitStatus.enabled?
   end
 
   def run_ci
@@ -98,6 +100,7 @@ EOF
       :completed_at => Time.now,
       :successful   => @result.success
     )
+    @build.mark_status_on_github_as(@result.success ? :success : :failure) if CommitStatus.enabled?
   end
 
   def fail(exception)
@@ -116,6 +119,8 @@ EOF
       :successful   => false,
       :output       => @build.output + failure_message
     )
+
+    @build.mark_status_on_github_as(:error) if CommitStatus.enabled?
   end
 
   def in_terminal

--- a/spec/fixtures/builds.yml
+++ b/spec/fixtures/builds.yml
@@ -1,6 +1,7 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/Fixtures.html
 
 one:
+  id: 1
   project_id: 1
   started_at: 2013-09-04 14:48:16
   completed_at: 2013-09-04 14:48:16
@@ -8,6 +9,7 @@ one:
   output: MyText
 
 two:
+  id: 2
   project_id: 1
   started_at: 2013-09-04 14:48:16
   completed_at: 2013-09-04 14:48:16

--- a/spec/fixtures/projects.yml
+++ b/spec/fixtures/projects.yml
@@ -1,7 +1,9 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/Fixtures.html
 
 one:
-  repo: MyString
+  id: 1
+  repo: project/one
 
 two:
-  repo: MyString
+  id: 2
+  repo: something/else

--- a/spec/models/commit_status_spec.rb
+++ b/spec/models/commit_status_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe CommitStatus do
+  let(:resource) { double("resource") }
+  let(:user) { "fakey" }
+  let(:token) { "ABCDEF123" }
+
+  context "with a username and token" do
+
+    before do
+      ENV["GITHUB_API_USER"], ENV["GITHUB_API_TOKEN"] = user, token
+    end
+
+    it 'sets a pending status' do
+      build = builds(:one)
+      repo_name = build.project.repo
+      sha       = build.sha
+      endpoint = "https://api.github.com/repos/#{repo_name}/statuses/#{sha}"
+
+      # Here's where we get RestClient::Resource to return the fake "resource" we're injecting...
+      expect(RestClient::Resource).to receive(:new).with(endpoint, user, token).and_return(resource)
+
+      commit_json = '{"state":"pending","description":"Build pending.","target_url":"http://localhost:6161/builds/1"}'
+      dict = { content_type: :json, accept: :json }
+
+      # ... and here's where we tell it how it should be called:
+      expect(resource).to receive(:post).with(commit_json, dict).and_return(nil)
+
+      CommitStatus.mark build.id, :pending
+      # If +resource+ doesn't get sent :post, or gets the wrong arguments, boom! spec failure.
+    end
+  end
+end


### PR DESCRIPTION
This branch ads a very simple set of functionality for informing GitHub’s [commit status API](http://developer.github.com/v3/repos/statuses/) of the status of builds. We could go down the route of a more general model as described in #16, but really I think this is simple enough a set of functionality that we don’t really need anything too complicated. Also, the commit status stuff isn’t just _after_ builds either, since it supports the addition of a `pending` status which we can send when the build starts, and then sending a secondary status to GitHub when the build finishes.

Thoughts?

If merged, this should close #2.
