### PR TITLE
Update build output while in progress

### DIFF
--- a/app/assets/javascripts/builds.js.coffee
+++ b/app/assets/javascripts/builds.js.coffee
@@ -1,3 +1,26 @@
 # Place all the behaviors and hooks related to the matching controller here.
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://coffeescript.org/
+
+$ ->
+  status = $('.js-build-status').attr('data-status')
+  if status != "true" && status != "false"
+    window.buildPollerId = setInterval ->
+      updateBuild()
+    , 1000
+
+updateBuild = ->
+  $.ajax
+    url: $('.js-build-output').attr('data-uri')
+    success: (build) ->
+      updateFields(build)
+
+updateFields = (build) ->
+  buildOutput = $('.js-build-output')
+  buildOutput.html(build.output)
+  buildOutput[0].scrollTop = buildOutput[0].scrollHeight
+  if build.successful isnt null
+    $('.js-build-status').html(build.status_phrase)
+    $('.js-build-status').attr('data-status', build.successful)
+    clearInterval(window.buildPollerId)
+    window.buildPollerId = undefined

--- a/app/assets/javascripts/builds.js.coffee
+++ b/app/assets/javascripts/builds.js.coffee
@@ -19,8 +19,8 @@ updateFields = (build) ->
   buildOutput = $('.js-build-output')
   buildOutput.html(build.output)
   buildOutput[0].scrollTop = buildOutput[0].scrollHeight
+  $('.js-build-status').html(build.status_phrase)
   if build.successful isnt null
-    $('.js-build-status').html(build.status_phrase)
     $('.js-build-status').attr('data-status', build.successful)
     clearInterval(window.buildPollerId)
     window.buildPollerId = undefined

--- a/app/views/builds/show.html.erb
+++ b/app/views/builds/show.html.erb
@@ -17,14 +17,9 @@
 
 <p>
   <strong>Status:</strong>
-  <%= @build.status_phrase %>
+  <span class="js-build-status" data-status="<%= @build.successful %>"><%= @build.status_phrase %></span>
 </p>
 
-<p>
-  <strong>Successful:</strong>
-  <%= @build.successful %>
-</p>
-
-<pre class="build-output">
+<pre class="build-output js-build-output" data-uri="<%= build_path(@build, :format => :json) %>">
 <%= @build.output %>
 </pre>

--- a/app/views/builds/show.json.jbuilder
+++ b/app/views/builds/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! @build, :project_id, :started_at, :completed_at, :successful, :output, :created_at, :updated_at
+json.extract! @build, :successful, :output, :status_phrase


### PR DESCRIPTION
This PR just adds a simple little JSON poller to update the build output in realtime as you view the page (well, every second at least):

![dciy-poller](https://f.cloud.github.com/assets/296432/1243940/856785b0-2a78-11e3-9899-2a9152182db9.gif)

It sets the timer on page load if the build hasn’t come back as successful or failed, and kills the timer if one is set as soon as the build finishes.
