### PR TITLE
Environment Based Security Token

### DIFF
--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -9,4 +9,8 @@
 
 # Make sure your secret_key_base is kept private
 # if you're sharing your code publicly.
-DCIY::Application.config.secret_key_base = ENV['RAILS_SECRET_TOKEN']
+DCIY::Application.config.secret_key_base = if Rails.env.development? or Rails.env.test?
+  ('secret' * 5)
+else
+  ENV['RAILS_SECRET_TOKEN']
+end

--- a/dciy.toml
+++ b/dciy.toml
@@ -1,3 +1,3 @@
 [dciy.commands]
-prepare = ["bundle install"]
+prepare = ["bundle install", "bundle exec rake db:migrate"]
 cibuild = ["bundle exec rake spec"]


### PR DESCRIPTION
`config.secret_key_base` relied on `RAILS_SECRET_TOKEN` being set in all environments. Since development and (especially) test environments are not guaranteed to have `RAILS_SECRET_TOKEN` set, a check was added for these environments to use a default value. Production will continue to **raise an error** when the environment variable is unset.

My build was still failing after the fix since the migrations were not being run. Migrations are now run as part of _prepare_ in `dciy.toml`.
