### PR TITLE
Fill in the build output with $(obj).text() instead of html()

### DIFF
--- a/app/assets/javascripts/builds.js.coffee
+++ b/app/assets/javascripts/builds.js.coffee
@@ -17,9 +17,9 @@ updateBuild = ->
 
 updateFields = (build) ->
   buildOutput = $('.js-build-output')
-  buildOutput.html(build.output)
+  buildOutput.text(build.output)
   buildOutput[0].scrollTop = buildOutput[0].scrollHeight
-  $('.js-build-status').html(build.status_phrase)
+  $('.js-build-status').text(build.status_phrase)
   if build.successful isnt null
     $('.js-build-status').attr('data-status', build.successful)
     clearInterval(window.buildPollerId)


### PR DESCRIPTION
Fixes #27.

Looks like jQuery was trying to `eval` the response from the build process, which kept failing. Calling `.text()` doesn't `eval` so it fills in the box no problem.
