### PR TITLE
GitHub:Enterprise support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ GITHUB_API_USER=REPLACEME
 GITHUB_API_TOKEN=REPLACEME
 
 # Set this to use DCIY with projects hosted on a GitHub:Enterprise install.
-# ENTERPRISE_HOST=github.starship-enterprise.com
+# ENTERPRISE_HOSTS=github.starship-enterprise.com
 
 # Replace the token below with something long and secure. Hint: run `rake secret` ;)
 RAILS_SECRET_TOKEN=REPLACEMEWITHSOMETHINGREALLYLONGANDSECURE

--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,8 @@
 GITHUB_API_USER=REPLACEME
 GITHUB_API_TOKEN=REPLACEME
 
+# Set this to use DCIY with projects hosted on a GitHub:Enterprise install.
+# ENTERPRISE_HOST=github.starship-enterprise.com
+
 # Replace the token below with something long and secure. Hint: run `rake secret` ;)
 RAILS_SECRET_TOKEN=REPLACEMEWITHSOMETHINGREALLYLONGANDSECURE

--- a/README.md
+++ b/README.md
@@ -107,6 +107,17 @@ DCIY will then go off and do the following:
 Keeping an eye on [`/builds`](http://localhost:6161/builds) will show you the status of the build
 as it runs in the background, and you can click on the build to view the output once it’s finished.
 
+### GitHub:Enterprise
+
+To use DCIY with a project on a GitHub:Enterprise instance, add a line to your `.env` file like so:
+
+```bash
+ENTERPRISE_HOST=github.starship-enterprise.com
+```
+
+Now, when you're creating or editing projects, you can choose `github.starship-enterprise.com` as a
+GitHub host.
+
 ## Contributing to DCIY
 
 I’d :heart: to receive contributions and feedback from anyone,

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ as it runs in the background, and you can click on the build to view the output 
 To use DCIY with a project on a GitHub:Enterprise instance, add a line to your `.env` file like so:
 
 ```bash
-ENTERPRISE_HOST=github.starship-enterprise.com
+ENTERPRISE_HOSTS=github.starship-enterprise.com
 ```
 
 Now, when you're creating or editing projects, you can choose `github.starship-enterprise.com` as a

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,6 +1,6 @@
 class ProjectsController < ApplicationController
   before_action :set_project, only: [:show, :edit, :update, :destroy]
-  after_action :set_hosts, only: [:new, :edit]
+  before_action :set_hosts, only: [:new, :edit]
 
   # GET /projects
   # GET /projects.json
@@ -70,11 +70,9 @@ class ProjectsController < ApplicationController
 
     # Derive a set of host choices from the project.
     def set_hosts
-      @hosts = [
-        ENV['ENTERPRISE_HOST'],
-        'github.com',
-        @project.github_host
-      ].reject(&:blank?).uniq
+      choices = [ENV['ENTERPRISE_HOST'], 'github.com']
+      choices << @project.github_host if @project
+      @hosts = choices.reject(&:blank?).uniq
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -70,7 +70,8 @@ class ProjectsController < ApplicationController
 
     # Derive a set of host choices from the project.
     def set_hosts
-      choices = [ENV['ENTERPRISE_HOST'], 'github.com']
+      choices = (ENV['ENTERPRISE_HOSTS'] || '').split(',')
+      choices << 'github.com'
       choices << @project.github_host if @project
       @hosts = choices.reject(&:blank?).uniq
     end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,5 +1,6 @@
 class ProjectsController < ApplicationController
   before_action :set_project, only: [:show, :edit, :update, :destroy]
+  after_action :set_hosts, only: [:new, :edit]
 
   # GET /projects
   # GET /projects.json
@@ -65,6 +66,15 @@ class ProjectsController < ApplicationController
     # Use callbacks to share common setup or constraints between actions.
     def set_project
       @project = Project.find(params[:id])
+    end
+
+    # Derive a set of host choices from the project.
+    def set_hosts
+      @hosts = [
+        ENV['ENTERPRISE_HOST'],
+        'github.com',
+        @project.github_host
+      ].reject(&:blank?).uniq
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -69,6 +69,6 @@ class ProjectsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def project_params
-      params.require(:project).permit(:repo)
+      params.require(:project).permit(:repo, :github_host)
     end
 end

--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -24,7 +24,7 @@ class CommitStatus
         "target_url" => "http://localhost:6161/builds/#{build.id}"
       }
 
-      endpoint = "https://api.github.com/repos/#{build.project.repo}/statuses/#{build.sha}"
+      endpoint = "#{build.project.api_uri}repos/#{build.project.repo}/statuses/#{build.sha}"
       repo_api = RestClient::Resource.new endpoint, ENV["GITHUB_API_USER"], ENV["GITHUB_API_TOKEN"]
 
       response = repo_api.post commit_status.to_json, :content_type => :json, :accept => :json

--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -24,7 +24,7 @@ class CommitStatus
         "target_url" => "http://localhost:6161/builds/#{build.id}"
       }
 
-      endpoint = "#{build.project.api_uri}repos/#{build.project.repo}/statuses/#{build.sha}"
+      endpoint = "#{build.project.api_uri}/repos/#{build.project.repo}/statuses/#{build.sha}"
       repo_api = RestClient::Resource.new endpoint, ENV["GITHUB_API_USER"], ENV["GITHUB_API_TOKEN"]
 
       response = repo_api.post commit_status.to_json, :content_type => :json, :accept => :json

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -21,9 +21,9 @@ class Project < ActiveRecord::Base
 
   def api_uri
     if github_host == "github.com"
-      "https://api.github.com/"
+      "https://api.github.com"
     else
-      "https://#{github_host}/api/v3/"
+      "https://#{github_host}/api/v3"
     end
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -16,7 +16,15 @@ class Project < ActiveRecord::Base
   end
 
   def repo_uri
-    "https://github.com/#{repo}"
+    "https://#{github_host}/#{repo}"
+  end
+
+  def api_uri
+    if github_host == "github.com"
+      "https://api.github.com/"
+    else
+      "https://#{github_host}/api/v3/"
+    end
   end
 
   def has_file? filename

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -13,7 +13,14 @@
 
   <div class="field">
     <%= f.label :repo, "Repository URL" %><br>
-    https://github.com/<%= f.text_field :repo, :placeholder => "owner/repository" %>
+    https://
+    <% if @hosts.size == 1 %>
+      <%= @hosts.first %>
+    <% else %>
+      <%= f.select :github_host, @hosts %>
+    <% end %>
+    /
+    <%= f.text_field :repo, :placeholder => "owner/repository" %>
   </div>
   <div class="actions">
     <%= f.submit %>

--- a/db/migrate/20140106022030_add_github_host_to_project.rb
+++ b/db/migrate/20140106022030_add_github_host_to_project.rb
@@ -1,0 +1,5 @@
+class AddGithubHostToProject < ActiveRecord::Migration
+  def change
+    add_column :projects, :github_host, :text, default: 'github.com'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20130927205508) do
+ActiveRecord::Schema.define(version: 20140106022030) do
 
   create_table "builds", force: true do |t|
     t.integer  "project_id"
@@ -25,10 +25,22 @@ ActiveRecord::Schema.define(version: 20130927205508) do
     t.string   "branch"
   end
 
+  create_table "post_build_actions", force: true do |t|
+    t.string   "type"
+    t.integer  "project_id"
+    t.integer  "trigger_on_status"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "trigger_on_branch"
+    t.string   "target_repo_uri"
+    t.string   "target_branch"
+  end
+
   create_table "projects", force: true do |t|
     t.string   "repo"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.text     "github_host", default: "github.com"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -25,17 +25,6 @@ ActiveRecord::Schema.define(version: 20140106022030) do
     t.string   "branch"
   end
 
-  create_table "post_build_actions", force: true do |t|
-    t.string   "type"
-    t.integer  "project_id"
-    t.integer  "trigger_on_status"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.string   "trigger_on_branch"
-    t.string   "target_repo_uri"
-    t.string   "target_branch"
-  end
-
   create_table "projects", force: true do |t|
     t.string   "repo"
     t.datetime "created_at"

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -44,34 +44,35 @@ describe ProjectsController do
 
     context "without an ENTERPRISE_HOST" do
       before do
-        allow(subject).to receive(:enterprise_host).and_return(nil)
+        allow(ENV).to receive(:[]).with('ENTERPRISE_HOST').and_return(nil)
       end
 
       it "shouldn't offer a choice of github host" do
         get :new, id: project
-        expect(assigns :choice).to eq([])
+        expect(assigns :hosts).to eq(["github.com"])
       end
 
       it "offers a choice if the project already specifies a different host" do
         get :edit, id: other_host
-        expect(assigns :choice).to eq(['github.com', other_host.github_host])
+        expect(assigns :hosts).to eq(['github.com', other_host.github_host])
       end
     end
 
     context "with an ENTERPRISE_HOST" do
       before do
-        allow(subject).to receive(:enterprise_host).and_return("github.starship-enterprise.com")
+        allow(ENV).to receive(:[]).with('ENTERPRISE_HOST').and_return('github.starship-enterprise.com')
       end
 
       it "should offer a choice of github hosts" do
         get :new, id: project
-        expect(assigns :choice).to eq(%w{github.com github.starship-enterprise.com})
+        expect(assigns :hosts).to eq(%w{github.starship-enterprise.com github.com})
       end
 
       it "offers the original host as a choice on existing projects" do
         get :edit, id: other_host
-        expect(assigns :choice).to eq(['github.com',
+        expect(assigns :hosts).to eq([
           'github.starship-enterprise.com',
+          'github.com',
           other_host.github_host])
       end
     end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -42,9 +42,9 @@ describe ProjectsController do
   describe "github host choices" do
     let(:other_host) { projects(:two) }
 
-    context "without an ENTERPRISE_HOST" do
+    context "without ENTERPRISE_HOSTS" do
       before do
-        allow(ENV).to receive(:[]).with('ENTERPRISE_HOST').and_return(nil)
+        allow(ENV).to receive(:[]).with('ENTERPRISE_HOSTS').and_return(nil)
       end
 
       it "shouldn't offer a choice of github host" do
@@ -58,20 +58,26 @@ describe ProjectsController do
       end
     end
 
-    context "with an ENTERPRISE_HOST" do
+    context "with ENTERPRISE_HOSTS" do
       before do
-        allow(ENV).to receive(:[]).with('ENTERPRISE_HOST').and_return('github.starship-enterprise.com')
+        allow(ENV).to receive(:[]).with('ENTERPRISE_HOSTS').and_return(
+          'github.starship-enterprise.com,github.galactica.com')
       end
 
       it "should offer a choice of github hosts" do
         get :new, id: project
-        expect(assigns :hosts).to eq(%w{github.starship-enterprise.com github.com})
+        expect(assigns :hosts).to eq(%w{
+          github.starship-enterprise.com
+          github.galactica.com
+          github.com
+        })
       end
 
       it "offers the original host as a choice on existing projects" do
         get :edit, id: other_host
         expect(assigns :hosts).to eq([
           'github.starship-enterprise.com',
+          'github.galactica.com',
           'github.com',
           other_host.github_host])
       end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -33,10 +33,48 @@ describe ProjectsController do
     expect(response).to be_success
   end
 
-  it "should get edit" do
+  it "should edit project" do
     get :edit, id: project
     expect(assigns :project).to eq(project)
     expect(response).to be_success
+  end
+
+  describe "github host choices" do
+    let(:other_host) { projects(:two) }
+
+    context "without an ENTERPRISE_HOST" do
+      before do
+        allow(subject).to receive(:enterprise_host).and_return(nil)
+      end
+
+      it "shouldn't offer a choice of github host" do
+        get :new, id: project
+        expect(assigns :choice).to eq([])
+      end
+
+      it "offers a choice if the project already specifies a different host" do
+        get :edit, id: other_host
+        expect(assigns :choice).to eq(['github.com', other_host.github_host])
+      end
+    end
+
+    context "with an ENTERPRISE_HOST" do
+      before do
+        allow(subject).to receive(:enterprise_host).and_return("github.starship-enterprise.com")
+      end
+
+      it "should offer a choice of github hosts" do
+        get :new, id: project
+        expect(assigns :choice).to eq(%w{github.com github.starship-enterprise.com})
+      end
+
+      it "offers the original host as a choice on existing projects" do
+        get :edit, id: other_host
+        expect(assigns :choice).to eq(['github.com',
+          'github.starship-enterprise.com',
+          other_host.github_host])
+      end
+    end
   end
 
   it "should update project" do

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -16,10 +16,13 @@ describe ProjectsController do
   end
 
   it "should create project" do
-    expect { post :create, project: { repo: 'foo/bar.git' } }.to change { Project.count }.by(1)
+    expect do
+      post :create, project: { repo: 'foo/bar.git', github_host: 'github.internal.com' }
+    end.to change { Project.count }.by(1)
 
     p = assigns :project
     expect(p.repo).to eq('foo/bar.git')
+    expect(p.github_host).to eq('github.internal.com')
 
     expect(response).to redirect_to(project_path(p))
   end
@@ -37,10 +40,14 @@ describe ProjectsController do
   end
 
   it "should update project" do
-    patch :update, id: project, project: { repo: 'something/different.git' }
+    patch :update, id: project, project: {
+      repo: 'something/different.git',
+      github_host: 'github.something.com'
+    }
 
     p = assigns :project
     expect(p.repo).to eq('something/different.git')
+    expect(p.github_host).to eq('github.something.com')
 
     assert_redirected_to project_path(assigns(:project))
   end

--- a/spec/fixtures/builds.yml
+++ b/spec/fixtures/builds.yml
@@ -10,7 +10,7 @@ one:
 
 two:
   id: 2
-  project_id: 1
+  project_id: 2
   started_at: 2013-09-04 14:48:16
   completed_at: 2013-09-04 14:48:16
   successful: false

--- a/spec/fixtures/projects.yml
+++ b/spec/fixtures/projects.yml
@@ -7,3 +7,4 @@ one:
 two:
   id: 2
   repo: something/else
+  github_host: github.internal.com

--- a/spec/models/commit_status_spec.rb
+++ b/spec/models/commit_status_spec.rb
@@ -5,6 +5,15 @@ describe CommitStatus do
   let(:user) { "fakey" }
   let(:token) { "ABCDEF123" }
 
+  def expect_post build, endpoint, payload
+    repo_name = build.project.repo
+    sha = build.sha
+    expect(RestClient::Resource).to receive(:new).with(endpoint, user, token).and_return(resource)
+
+    dict = { content_type: :json, accept: :json }
+    expect(resource).to receive(:post).with(payload.to_json, dict).and_return(nil)
+  end
+
   context "with a username and token" do
     before do
       ENV["GITHUB_API_USER"], ENV["GITHUB_API_TOKEN"] = user, token
@@ -12,18 +21,12 @@ describe CommitStatus do
 
     it 'sets a pending status' do
       build = builds(:one)
-      repo_name = build.project.repo
-      sha       = build.sha
-      endpoint = "https://api.github.com/repos/#{repo_name}/statuses/#{sha}"
-
-      # Here's where we get RestClient::Resource to return the fake "resource" we're injecting...
-      expect(RestClient::Resource).to receive(:new).with(endpoint, user, token).and_return(resource)
-
-      commit_json = '{"state":"pending","description":"Build pending.","target_url":"http://localhost:6161/builds/1"}'
-      dict = { content_type: :json, accept: :json }
-
-      # ... and here's where we tell it how it should be called:
-      expect(resource).to receive(:post).with(commit_json, dict).and_return(nil)
+      endpoint = "https://api.github.com/repos/#{build.project.repo}/statuses/#{build.sha}"
+      expect_post build, endpoint, {
+        state: "pending",
+        description: "Build pending.",
+        target_url: "http://localhost:6161/builds/#{build.id}"
+      }
 
       CommitStatus.mark build.id, :pending
       # If +resource+ doesn't get sent :post, or gets the wrong arguments, boom! spec failure.
@@ -31,16 +34,12 @@ describe CommitStatus do
 
     it "uses the project's GitHub API endpoint" do
       build = builds(:two)
-      repo_name = build.project.repo
-      sha = build.sha
-      endpoint = "https://github.internal.com/api/v3/repos/#{repo_name}/statuses/#{sha}"
-
-      expect(RestClient::Resource).to receive(:new).with(endpoint, user, token).and_return(resource)
-
-      commit_json = '{"state":"pending","description":"Build pending.","target_url":"http://localhost:6161/builds/2"}'
-      dict = { content_type: :json, accept: :json }
-
-      expect(resource).to receive(:post).with(commit_json, dict)
+      endpoint = "https://github.internal.com/api/v3/repos/#{build.project.repo}/statuses/#{build.sha}"
+      expect_post build, endpoint, {
+        state: "pending",
+        description: "Build pending.",
+        target_url: "http://localhost:6161/builds/#{build.id}"
+      }
 
       CommitStatus.mark build.id, :pending
     end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -3,8 +3,28 @@ require 'spec_helper'
 describe Project do
   let(:project) { Project.create! repo: 'cobyism/dciy.git' }
 
-  it 'generates a git URI' do
-    expect(project.repo_uri).to eq('https://github.com/cobyism/dciy.git')
+  context 'with the default github uri' do
+    it 'generates a git URI' do
+      expect(project.repo_uri).to eq('https://github.com/cobyism/dciy.git')
+    end
+
+    it "locates the base URI for github's API" do
+      expect(project.api_uri).to eq('https://api.github.com/')
+    end
+  end
+
+  context 'given a github:enterprise endpoint' do
+    before do
+      project.github_host = 'github.internal.com'
+    end
+
+    it 'generates git URIs within the instance' do
+      expect(project.repo_uri).to eq('https://github.internal.com/cobyism/dciy.git')
+    end
+
+    it 'locates the API' do
+      expect(project.api_uri).to eq('https://github.internal.com/api/v3/')
+    end
   end
 
   it 'derives a workspace path' do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -9,7 +9,7 @@ describe Project do
     end
 
     it "locates the base URI for github's API" do
-      expect(project.api_uri).to eq('https://api.github.com/')
+      expect(project.api_uri).to eq('https://api.github.com')
     end
   end
 
@@ -23,7 +23,7 @@ describe Project do
     end
 
     it 'locates the API' do
-      expect(project.api_uri).to eq('https://github.internal.com/api/v3/')
+      expect(project.api_uri).to eq('https://github.internal.com/api/v3')
     end
   end
 


### PR DESCRIPTION
We've got a GitHub:Enterprise instance and it'd be neat to be able to use DCIY with it. I think it makes sense to support Enterprise, especially since DCIY is mostly useful for non-public repositories.

If an `ENTERPRISE_HOST` environment variable is set, DCIY will give you a dropdown for the hostname when you're creating or editing a `Project`, letting you choose between the enterprise host, github.com, or whatever the project is already using (so it doesn't get all weird if you change the setting around):

![dciy-enterprise-dropdown](https://f.cloud.github.com/assets/17565/1860420/171728d0-77b3-11e3-8921-dc5be91bf1de.png)
