### PR TITLE
Default script/server to production mode

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -20,7 +20,7 @@ DCIY::Application.configure do
   # config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_assets = false
+  config.serve_static_assets = true
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -2,3 +2,8 @@
 
 bundle install
 bundle exec rake db:migrate
+
+if [ "$RAILS_ENV" == "production" ]
+then
+    bundle exec rake assets:precompile
+fi

--- a/script/server
+++ b/script/server
@@ -1,4 +1,9 @@
 #!/bin/bash
 
+if [ -z "$RAILS_ENV" ]
+then
+    export RAILS_ENV="production"
+fi
+
 script/bootstrap
 bundle exec foreman start


### PR DESCRIPTION
- `script/server` now sets RAILS_ENV=production if RAILS_ENV is not
  already set
- `script/bootstrap` precompiles assets when in production
- The production environment is set to serve static assets by default.
  This assumes that most folks won't be running DCIY behind any sort of
  reverse proxy.
- Add note about static content to README.

These changes address discussion in cobyism/dciy#22.
