### PR TITLE
Validate empty repo

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,6 +1,6 @@
 class ProjectsController < ApplicationController
   before_action :set_project, only: [:show, :edit, :update, :destroy]
-  before_action :set_hosts, only: [:new, :edit]
+  before_action :set_hosts, only: [:new, :edit, :create, :update]
 
   # GET /projects/1
   # GET /projects/1.json

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,7 +1,10 @@
 class Project < ActiveRecord::Base
   has_many :builds, :dependent => :destroy
 
-  validates :repo, presence: true
+  validates :repo, presence: true, format: {
+    with: %r{\A[^/]+/[^/]+\z},
+    message: "Must have the form 'owner/repository'"
+  }
 
   BuildInstructions = Struct.new(:prepare_cmds, :ci_cmds)
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,8 @@
 class Project < ActiveRecord::Base
   has_many :builds, :dependent => :destroy
 
+  validates :repo, presence: true
+
   BuildInstructions = Struct.new(:prepare_cmds, :ci_cmds)
 
   def workspace_path

--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -21,6 +21,7 @@ class Runner
     do_ascii_header
     add_dciy_build_output "Aight, let's do this!"
     begin
+      ENV['GIT_ASKPASS'] = 'echo'
       do_checkout
       run_prepare && run_ci
     rescue CantFindBuildFile

--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -5,6 +5,8 @@ class Runner
 
   class BranchNotFoundError < StandardError; end
 
+  class CheckoutFailedError < StandardError; end
+
   def self.go_nuts_on(build)
     new(build).run_run_run
   end
@@ -21,7 +23,6 @@ class Runner
     do_ascii_header
     add_dciy_build_output "Aight, let's do this!"
     begin
-      ENV['GIT_ASKPASS'] = 'echo'
       do_checkout
       run_prepare && run_ci
     rescue CantFindBuildFile
@@ -51,16 +52,28 @@ EOF
   end
 
   def do_checkout
-
     @logger.info "Started building #{@project.repo} at #{Time.now}"
     @build.update(:started_at => Time.now)
 
+    # Keep git from prompting for passwords!
+    ENV['GIT_ASKPASS'] = 'echo'
+
     if File.exists?(@directory)
       add_dciy_build_output "Updating repository..."
-      in_terminal.run "git fetch origin", @directory
+      fetch_command = "git fetch origin"
+      r = in_terminal.run fetch_command, @directory
     else
       add_dciy_build_output "Cloning repository..."
-      in_terminal.run "git clone #{@project.repo_uri} #{@directory}"
+      fetch_command = "git clone #{@project.repo_uri} #{@directory}"
+      r = in_terminal.run fetch_command
+    end
+
+    unless r.success
+      add_dciy_build_output "Oh, snap! I couldn't fetch the project."
+      add_output "The command I tried was:\n\n" +
+        "#{fetch_command}\n\n... and the output I got was:\n\n" +
+        "#{r.output}\n\n"
+      raise CheckoutFailedError, "Unable to fetch the project."
     end
 
     add_dciy_build_output "Looking up SHA for branch '#{@build.branch}'"

--- a/spec/models/build_spec.rb
+++ b/spec/models/build_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'time'
 
 describe Build do
-  let(:project) { Project.create! }
+  let(:project) { Project.create! repo: 'cobyism/dciy' }
   let(:now) { Time.parse '1 Jan 2013 12:00am GMT' }
 
   before do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -8,7 +8,7 @@ describe Project do
     expect(p).not_to be_valid
   end
 
-  it "must have the format username/repo" do
+  it "must have the format owner/repo" do
     %w{tooshort too/many/parts}.each do |bad|
       Project.create(repo: bad).should_not be_valid, "incorrectly accepted #{bad}"
     end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -8,6 +8,16 @@ describe Project do
     expect(p).not_to be_valid
   end
 
+  it "must have the format username/repo" do
+    %w{tooshort too/many/parts}.each do |bad|
+      Project.create(repo: bad).should_not be_valid, "incorrectly accepted #{bad}"
+    end
+  end
+
+  it "accepts a correctly formatted repo" do
+    project.should be_valid
+  end
+
   context 'with the default github uri' do
     it 'generates a git URI' do
       expect(project.repo_uri).to eq('https://github.com/cobyism/dciy.git')

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -3,6 +3,11 @@ require 'spec_helper'
 describe Project do
   let(:project) { Project.create! repo: 'cobyism/dciy.git' }
 
+  it "requires a non-empty repo URI" do
+    p = Project.create repo: ''
+    expect(p).not_to be_valid
+  end
+
   context 'with the default github uri' do
     it 'generates a git URI' do
       expect(project.repo_uri).to eq('https://github.com/cobyism/dciy.git')


### PR DESCRIPTION
This addresses #23 by:
- Adding validation to the `Project` model.
- Fixing a bug in `ProjectsController` that only shows up when validation fails :wink:
- Reporting the output of `git fetch` or `git clone` when either fail, and failing the build then too.

I also prevented `git` from holding up Sidekiq by asking for a password on stdin while I was at it, since I did some testing against private repos on GitHub.
