### PR TITLE
[WIP] Accept Github webhooks payload

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -4,7 +4,7 @@ class WebhooksController < ApplicationController
 
   # POST /webhooks/receive
   def receive
-    push = JSON.parse(params[:payload])
+    payload = JSON.parse(params[:payload])
     p = Project.where(id: params[:project_id]).take
 
     unless p
@@ -13,7 +13,7 @@ class WebhooksController < ApplicationController
       return
     end
 
-    bname = push['ref']
+    bname = payload['ref']
     bname.gsub!(%r{^refs/heads/}, '') if bname
     b = p.builds.create! branch: bname
 

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -1,13 +1,14 @@
 class WebhooksController < ApplicationController
 
+  protect_from_forgery with: :null_session
+
   # POST /webhooks/receive
   def receive
     push = JSON.parse(params[:payload])
-
-    pname = push.fetch('repository', {})['name']
-    p = Project.where(repo: pname).take
+    p = Project.where(id: params[:project_id]).take
 
     unless p
+      # Raise a 404 manually so we don't get a helpful HTML response body.
       head :not_found
       return
     end

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -2,5 +2,22 @@ class WebhooksController < ApplicationController
 
   # POST /webhooks/receive
   def receive
+    push = JSON.parse(params[:payload])
+
+    pname = push.fetch('repository', {})['name']
+    p = Project.where(repo: pname).take
+
+    unless p
+      head :not_found
+      return
+    end
+
+    bname = push['ref']
+    bname.gsub!(%r{^refs/heads/}, '') if bname
+    b = p.builds.create! branch: bname
+
+    BuildWorker.perform_async(b.id)
+
+    head :created
   end
 end

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -1,0 +1,6 @@
+class WebhooksController < ApplicationController
+
+  # POST /webhooks/receive
+  def receive
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ DCIY::Application.routes.draw do
     resources :builds, :except => [:edit, :update]
   end
 
-  post "webhooks/receive"
+  post "webhooks/receive/:project_id" => "webhooks#receive"
 
   root to: "builds#index"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ DCIY::Application.routes.draw do
     resources :builds, :except => [:edit, :update]
   end
 
+  post "webhooks/receive"
+
   root to: "builds#index"
 
   require 'sidekiq/web'

--- a/spec/controllers/webhooks_controller_spec.rb
+++ b/spec/controllers/webhooks_controller_spec.rb
@@ -11,12 +11,7 @@ describe WebhooksController do
       # Reference:
       # https://help.github.com/articles/post-receive-hooks#the-payload
       expect do
-        post :receive, payload: {
-          ref: 'refs/heads/master',
-          repository: {
-            name: 'cobyism/dciy'
-          }
-        }.to_json
+        post :receive, project_id: project.id, payload: { ref: 'refs/heads/master' }.to_json
       end.to change { project.builds.count }.by(1)
 
       expect(response).to be_success
@@ -26,12 +21,7 @@ describe WebhooksController do
     end
 
     it "returns a 404 on unknown projects" do
-      post :receive, payload: {
-        ref: 'refs/heads/master',
-        repository: {
-          name: 'attacker/exploitz'
-        }
-      }.to_json
+      post :receive, project_id: 12, payload: { ref: 'refs/heads/master' }.to_json
 
       expect(response).to be_not_found
     end

--- a/spec/controllers/webhooks_controller_spec.rb
+++ b/spec/controllers/webhooks_controller_spec.rb
@@ -21,7 +21,7 @@ describe WebhooksController do
     end
 
     it "returns a 404 on unknown projects" do
-      post :receive, project_id: 12, payload: { ref: 'refs/heads/master' }.to_json
+      post :receive, project_id: 9999999, payload: { ref: 'refs/heads/master' }.to_json
 
       expect(response).to be_not_found
     end

--- a/spec/controllers/webhooks_controller_spec.rb
+++ b/spec/controllers/webhooks_controller_spec.rb
@@ -2,10 +2,38 @@ require 'spec_helper'
 
 describe WebhooksController do
 
-  describe "GET 'receive'" do
-    it "returns http success" do
-      get 'receive'
-      response.should be_success
+  describe "POST 'receive'" do
+    let!(:project) { Project.create! repo: 'cobyism/dciy' }
+
+    it "creates a new build for that ref, on that project" do
+      expect(BuildWorker).to receive(:perform_async)
+
+      # Reference:
+      # https://help.github.com/articles/post-receive-hooks#the-payload
+      expect do
+        post :receive, payload: {
+          ref: 'refs/heads/master',
+          repository: {
+            name: 'cobyism/dciy'
+          }
+        }.to_json
+      end.to change { project.builds.count }.by(1)
+
+      expect(response).to be_success
+      expect(project.builds).to have(1).item
+      b = project.builds[0]
+      expect(b.branch).to eq("master")
+    end
+
+    it "returns a 404 on unknown projects" do
+      post :receive, payload: {
+        ref: 'refs/heads/master',
+        repository: {
+          name: 'attacker/exploitz'
+        }
+      }.to_json
+
+      expect(response).to be_not_found
     end
   end
 

--- a/spec/controllers/webhooks_controller_spec.rb
+++ b/spec/controllers/webhooks_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe WebhooksController do
+
+  describe "GET 'receive'" do
+    it "returns http success" do
+      get 'receive'
+      response.should be_success
+    end
+  end
+
+end


### PR DESCRIPTION
This is the first step in implementing #5. Add a webhook to your repository with a URL in the following format:

```
http://<your-ip>:6161/webhooks/receive/<project-id>
```

... and DCIY will automatically build branches when they're pushed. Pretty neat! It's starting to feel like a proper CI, now.

This is the very core functionality for that ticket, though; it's pretty unrefined. What's left to do:
- [ ] Show new builds live as they happen, with some kind of CoffeeScript polling on `projects/:id/builds`.
- [ ] Either add a button to register the hook with the GitHub instance, or show you a "help" page that walks you through how to do it.
- [ ] Build incoming pull requests, too! Maybe. This has Security Implications :tm: like @cobyism brought up earlier.
